### PR TITLE
Revert "Merge fix for Bison errors"

### DIFF
--- a/gcc-2.95.3/gcc/c-parse.y
+++ b/gcc-2.95.3/gcc/c-parse.y
@@ -80,10 +80,6 @@ char *language_string = "GNU C";
 
 /* Cause the `yydebug' variable to be defined.  */
 #define YYDEBUG 1
-
-#ifndef YYLEX
-#define YYLEX yylex()
-#endif
 %}
 
 %start program
@@ -1325,7 +1321,7 @@ enum_head:
 
 structsp:
 	  struct_head identifier '{'
-		{ $<ttype>$ = start_struct (RECORD_TYPE, $2);
+		{ $$ = start_struct (RECORD_TYPE, $2);
 		  /* Start scope of tag before parsing components.  */
 		}
 	  component_decl_list '}' maybe_attribute 
@@ -1337,7 +1333,7 @@ structsp:
 	| struct_head identifier
 		{ $$ = xref_tag (RECORD_TYPE, $2); }
 	| union_head identifier '{'
-		{ $<ttype>$ = start_struct (UNION_TYPE, $2); }
+		{ $$ = start_struct (UNION_TYPE, $2); }
 	  component_decl_list '}' maybe_attribute
 		{ $$ = finish_struct ($<ttype>4, $5, chainon ($1, $7)); }
 	| union_head '{' component_decl_list '}' maybe_attribute
@@ -1348,13 +1344,13 @@ structsp:
 		{ $$ = xref_tag (UNION_TYPE, $2); }
 	| enum_head identifier '{'
 		{ $<itype>3 = suspend_momentary ();
-		  $<ttype>$ = start_enum ($2); }
+		  $$ = start_enum ($2); }
 	  enumlist maybecomma_warn '}' maybe_attribute
 		{ $$= finish_enum ($<ttype>4, nreverse ($5), chainon ($1, $8));
 		  resume_momentary ($<itype>3); }
 	| enum_head '{'
 		{ $<itype>2 = suspend_momentary ();
-		  $<ttype>$ = start_enum (NULL_TREE); }
+		  $$ = start_enum (NULL_TREE); }
 	  enumlist maybecomma_warn '}' maybe_attribute
 		{ $$= finish_enum ($<ttype>3, nreverse ($4), chainon ($1, $7));
 		  resume_momentary ($<itype>2); }

--- a/gcc-2.95.3/gcc/cp/parse.y
+++ b/gcc-2.95.3/gcc/cp/parse.y
@@ -55,10 +55,6 @@ extern int end_of_file;
 /* Like YYERROR but do call yyerror.  */
 #define YYERROR1 { yyerror ("syntax error"); YYERROR; }
 
-#ifndef YYLEX
-#define YYLEX yylex
-#endif
-
 #define OP0(NODE) (TREE_OPERAND (NODE, 0))
 #define OP1(NODE) (TREE_OPERAND (NODE, 1))
 
@@ -657,7 +653,7 @@ fndef:
 
 constructor_declarator:
 	  nested_name_specifier SELFNAME '(' 
-                { $<ttype>$ = begin_constructor_declarator ($1, $2); }
+                { $$ = begin_constructor_declarator ($1, $2); }
 	  parmlist ')' cv_qualifiers exception_specification_opt
 		{ $$ = make_call_declarator ($<ttype>4, $5, $7, $8); }
 	| nested_name_specifier SELFNAME LEFT_RIGHT cv_qualifiers exception_specification_opt
@@ -665,7 +661,7 @@ constructor_declarator:
 		  $$ = make_call_declarator ($$, empty_parms (), $4, $5);
 		}
 	| global_scope nested_name_specifier SELFNAME '(' 
-                { $<ttype>$ = begin_constructor_declarator ($2, $3); }
+                { $$ = begin_constructor_declarator ($2, $3); }
 	 parmlist ')' cv_qualifiers exception_specification_opt
 		{ $$ = make_call_declarator ($<ttype>5, $6, $8, $9); }
 	| global_scope nested_name_specifier SELFNAME LEFT_RIGHT cv_qualifiers exception_specification_opt
@@ -673,7 +669,7 @@ constructor_declarator:
 		  $$ = make_call_declarator ($$, empty_parms (), $5, $6);
 		}
 	| nested_name_specifier self_template_type '(' 
-                { $<ttype>$ = begin_constructor_declarator ($1, $2); }
+                { $$ = begin_constructor_declarator ($1, $2); }
 	  parmlist ')' cv_qualifiers exception_specification_opt
 		{ $$ = make_call_declarator ($<ttype>4, $5, $7, $8); }
 	| nested_name_specifier self_template_type LEFT_RIGHT cv_qualifiers exception_specification_opt
@@ -681,7 +677,7 @@ constructor_declarator:
 		  $$ = make_call_declarator ($$, empty_parms (), $4, $5);
 		}
 	| global_scope nested_name_specifier self_template_type '(' 
-                { $<ttype>$ = begin_constructor_declarator ($2, $3); }
+                { $$ = begin_constructor_declarator ($2, $3); }
 	 parmlist ')' cv_qualifiers exception_specification_opt
 		{ $$ = make_call_declarator ($<ttype>5, $6, $8, $9); }
 	| global_scope nested_name_specifier self_template_type LEFT_RIGHT cv_qualifiers exception_specification_opt


### PR DESCRIPTION
Reverts jichu4n/prc-tools-remix#6

After some experimentation, it looks like newer Bison implementations will continue to wreak havoc on the compilation and require even more fixes than these.

Given that the intention of this repo is to "freeze" the toolchain as-is, I think the most future-proof fix is to freeze the output (`c-parse.c` etc) and not even run Bison at all.

I'll revert this PR in preparation of the above.