### PR TITLE
Fix missing DESTDIR reference in GCC 2.95 install-headers target.

### DIFF
--- a/gcc-2.95.3/gcc/Makefile.in
+++ b/gcc-2.95.3/gcc/Makefile.in
@@ -2664,7 +2664,7 @@ install-headers-tar: stmp-headers $(STMP_FIXPROTO) install-include-dir
 # found in CDPATH, corrupting the output.  We could just redirect the
 # output of `cd', but some shells lose on redirection within `()'s
 	(cd `pwd`/include ; \
-	 tar -cf - .; exit 0) | (cd $(libsubdir)/include; tar $(TAROUTOPTS) - )
+	 tar -cf - .; exit 0) | (cd $(DESTDIR)$(libsubdir)/include; tar $(TAROUTOPTS) - )
 # /bin/sh on some systems returns the status of the first tar,
 # and that can lose with GNU tar which always writes a full block.
 # So use `exit 0' to ignore its exit status.
@@ -2673,7 +2673,7 @@ install-headers-tar: stmp-headers $(STMP_FIXPROTO) install-include-dir
 install-headers-cpio: stmp-headers $(STMP_FIXPROTO) install-include-dir
 # See discussion about the use of `pwd` above
 	cd `pwd`/include ; \
-	find . -print | cpio -pdum $(libsubdir)/include
+	find . -print | cpio -pdum $(DESTDIR)$(libsubdir)/include
 
 # Put assert.h where it won't override GNU libc's assert.h.
 # It goes in a dir that is searched after GNU libc's headers;


### PR DESCRIPTION
This was missed in earlier patches to enable DESTDIR support in GCC 2.95. Fixes build error in Arch Linux.